### PR TITLE
definitions: define what SHA1 means, including collision detection logic

### DIFF
--- a/Chapters/3.Terms_and_definitions.md
+++ b/Chapters/3.Terms_and_definitions.md
@@ -34,9 +34,21 @@ An identifier that can be computed directly from the object that it identifies, 
 
 its definition
 
-**sha1_git**
+**SHA1**
 
-its definition
+*SHA-1* (short for "Secure Hash Algorithm 1", also stylized as "*SHA1*") is a hash function that takes as input a sequence of bytes and produces a 160-bit (20-byte) hash value.
+The returned value is called *SHA1 checksum*, or simply *SHA1* when there is no risk of ambiguity between the function and the returned value.
+A detailed description of how to compute SHA1 is available in RFC-3174.
+
+In the wake of the [Shattered attack](https://shattered.io/) of 2017 (see paper: [Stevens2017Shattered](B.Bibliography.md)), it is now possible to produce collision-prone files that are different but return the same SHA1 checksums.
+It is however possible to detect, during SHA1 computation, such SHA1-colliding files using counter-cryptanalysis (see paper: [Stevens2013Counter](B.Bibliography.md)).
+
+As collision-prone files are problematic from the point of view of unequivocal identification and integrity verification, the SWHID standard takes measures to avoid that such files are referenced using only SHA1 checksums.
+For the purpose of this specification document, the SHA1 function is therefore considered to be a *partial* function, that only returns a value when a Shattered-style collision is not detectable using the techniques described in [Stevens2013Counter](B.Bibliography.md) and the reference implementation of it available at <https://github.com/cr-marcstevens/sha1collisiondetection> (version `stable-v1.0.3`, corresponding to Git commit ID `38096fc021ac5b8f8207c7e926f11feb6b5eb17c`).
+
+When such a collision is detected during SHA1 computation, no SHA1 can be obtained for the object in question and hence, depending on the context, a valid SWHID might not exist for it.
+
+Note that in most cases SHA1 in this specification are computed on objects after adding specific headers to them, making "trivial" collision-prone files still perfectly valid and hence referenceable using SWHIDs.
 
 **version control system**
 

--- a/Chapters/B.Bibliography.md
+++ b/Chapters/B.Bibliography.md
@@ -4,3 +4,6 @@ The following documents are useful references for implementers and users of this
 
 [1] *SoftWare Heritage persistent IDentifiers*; SoftWare Heritage, <https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html>
 
+[Stevens2013Counter] Marc Stevens. Counter-cryptanalysis. In Advances in Cryptology, CRYPTO 2013: 33rd Annual Cryptology Conference, Santa Barbara, CA, USA, August 18-22, 2013. Proceedings, Part I (pp. 129-146). Springer Berlin Heidelberg. Open access preprint: <https://eprint.iacr.org/2013/358>
+
+[Stevens2017Shattered] Marc Stevens, Elie Bursztein, Pierre Karpman, Ange Albertini, Yarik Markov. The First Collision for Full SHA-1. In Advances in Cryptology, CRYPTO 2017: 37th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 20–24, 2017, Proceedings, Part I 37 (pp. 570-596). Springer International Publishing. Open access preprint: <https://eprint.iacr.org/2017/190>


### PR DESCRIPTION
This is a first take at addressing #16.

The main idea is a bit radical: stating that a SHA1 does not exist when a Shattered collision (not any detectable collection existing in the future!, only what we know today) is detectable.
As SHA1 wasn't defined yet in the list of definitions, I just mentioned all of this there, with supporting scientific references as well as pointers to the existing reference implementation.

Happy to discuss…
