### PR TITLE
Fixes a typo on function name

### DIFF
--- a/Chapters/6.Qualified_identifiers.md
+++ b/Chapters/6.Qualified_identifiers.md
@@ -36,7 +36,7 @@ The range can be a single line number, or a pair of line numbers separated by th
 Line numbers start from 1, and range is inclusive, i.e. the fragment includes both the lines numbered as start and end of the range.
 
 For example, [`swh:1:cnt:4d99d2d18326621ccdd70f5ea66c2e2ac236ad8b;lines=9-15`](https://archive.softwareheritage.org/swh:1:cnt:4d99d2d18326621ccdd70f5ea66c2e2ac236ad8b;lines=9-15)
-designates the function `generate_intput_stream` that is found at lines 9 to 15 of the *content* with core SWHID `swh:1:cnt:4d99d2d18326621ccdd70f5ea66c2e2ac236ad8b`.
+designates the function `generate_input_stream` that is found at lines 9 to 15 of the *content* with core SWHID `swh:1:cnt:4d99d2d18326621ccdd70f5ea66c2e2ac236ad8b`.
 
 Notice that the notion of "line number" is not always meaningful: the content
 may be a binary file, or a file that uses non standard line termination character(s).
@@ -49,7 +49,7 @@ Byte numbers start from 0, and range is inclusive, i.e. the fragment includes bo
 If the range is a single byte number, it designates the byte at that specific position.
 
 For example, `swh:1:cnt:4d99d2d18326621ccdd70f5ea66c2e2ac236ad8b;bytes=154-315`
-designates the same function `generate_intput_stream` as in the example above, but
+designates the same function `generate_input_stream` as in the example above, but
 does not rely on any convention about line numbers.
 
 
@@ -61,7 +61,7 @@ This qualifier allows to declare the *software origin* where the
 object has been found or observed, as an URI.
 
 For example, [`swh:1:cnt:4d99d2d18326621ccdd70f5ea66c2e2ac236ad8b;origin=https://gitorious.org/ocamlp3l/ocamlp3l_cvs.git`](https://archive.softwareheritage.org/swh:1:cnt:4d99d2d18326621ccdd70f5ea66c2e2ac236ad8b;origin=https://gitorious.org/ocamlp3l/ocamlp3l_cvs.git)
-indicates that the content seen previously with the function `generate_intput_stream` has
+indicates that the content seen previously with the function `generate_input_stream` has
 been seen in the Git repository at `https://gitorious.org/ocamlp3l/ocamlp3l_cvs.git`
 
 This qualifier may be helpful to get hold of the full repository where a
@@ -75,7 +75,7 @@ This qualifier allows to add the core SWHID identifier of the *snapshot*
 of the repository where the object has been found or observed.
 
 For example, [`swh:1:cnt:4d99d2d18326621ccdd70f5ea66c2e2ac236ad8b;origin=https://gitorious.org/ocamlp3l/ocamlp3l_cvs.git;visit=swh:1:snp:d7f1b9eb7ccb596c2622c4780febaa02549830f9`](https://archive.softwareheritage.org/swh:1:cnt:4d99d2d18326621ccdd70f5ea66c2e2ac236ad8b;origin=https://gitorious.org/ocamlp3l/ocamlp3l_cvs.git;visit=swh:1:snp:d7f1b9eb7ccb596c2622c4780febaa02549830f9)
-indicates that the content seen previously with the function `generate_intput_stream` has
+indicates that the content seen previously with the function `generate_input_stream` has
 been seen in the Git repository at `https://gitorious.org/ocamlp3l/ocamlp3l_cvs.git`, when
 its full state had the SWHID core identifier `swh:1:snp:d7f1b9eb7ccb596c2622c4780febaa02549830f9`. 
 
@@ -92,7 +92,7 @@ the root directory is the first directory reachable from the `HEAD` branch,
 and undefined if such a reference is missing.
 
 For example, [`swh:1:cnt:4d99d2d18326621ccdd70f5ea66c2e2ac236ad8b;origin=https://gitorious.org/ocamlp3l/ocamlp3l_cvs.git;visit=swh:1:snp:d7f1b9eb7ccb596c2622c4780febaa02549830f9;anchor=swh:1:rev:2db189928c94d62a3b4757b3eec68f0a4d4113f0;path=/Examples/SimpleFarm/simplefarm.ml`](https://archive.softwareheritage.org/swh:1:cnt:4d99d2d18326621ccdd70f5ea66c2e2ac236ad8b;origin=https://gitorious.org/ocamlp3l/ocamlp3l_cvs.git;visit=swh:1:snp:d7f1b9eb7ccb596c2622c4780febaa02549830f9;anchor=swh:1:rev:2db189928c94d62a3b4757b3eec68f0a4d4113f0;path=/Examples/SimpleFarm/simplefarm.ml)
-indicates that the content seen previously with the function `generate_intput_stream` has
+indicates that the content seen previously with the function `generate_input_stream` has
 been seen in the Git repository at `https://gitorious.org/ocamlp3l/ocamlp3l_cvs.git`, when
 its full state had the SWHID core identifier `swh:1:snp:d7f1b9eb7ccb596c2622c4780febaa02549830f9`, and that it is named `simplefarm.ml` in the directory `Simplefarm` contained in the directory `Examples` contained in the root directory associated to the revision with core SWHID `swh:1:rev:2db189928c94d62a3b4757b3eec68f0a4d4113f0`.
 


### PR DESCRIPTION
"intput" should be "input"
in all references to `generate_input_stream` function

Signed-off-by: Alexios Zavras <github@zvr.gr>
