### PR TITLE
Fixes directory access bits in Core Identifiers

### DIFF
--- a/Chapters/5.Core_identifiers.md
+++ b/Chapters/5.Core_identifiers.md
@@ -58,7 +58,7 @@ Then a serialization of the directory is created, as follows:
    2. sort all entries using the byte order of their (modified) name
 
 2. for each entry, with a given *name* (unmodified), add a sequence of bytes composed of
-   1. the normalized access rights, encoded as a sequence of ASCII-encoded octal digits ('100644' for regular [i.e., non-special] files, '100755' for executable files, '120000' for symbolic links, and '40000' for directories),
+   1. the normalized access rights, encoded as a sequence of ASCII-encoded octal digits ('100644' for regular [i.e., non-special] files, '100755' for executable files, '120000' for symbolic links, and '040000' for directories),
    2. an ASCII space,
    3. the *name* as a string of bytes,
    4. a NULL byte,


### PR DESCRIPTION
Updates 5.Core_identifiers.md with the correct access bytes for directories.
