### PR TITLE
The text and link were in the wrong order

### DIFF
--- a/Chapters/0.Foreword.md
+++ b/Chapters/0.Foreword.md
@@ -2,7 +2,7 @@
 
 This document contains the Publicly Available Specification of the
 SWHID identifier, which was used as a starting point for the creation
-of the [https://www.iso.org/standard/89985.html](ISO/IEC standard 18670).
+of the [ISO/IEC standard 18670](https://www.iso.org/standard/89985.html).
 
 ISO (the International Organization for Standardization)
 is a worldwide federation of national standards bodies (ISO member bodies).


### PR DESCRIPTION
"Doc file '0.Foreword.md' contains an unrecognized relative link 'ISO/IEC standard 18670', it was left as is."